### PR TITLE
Nuget update Microsoft.CodeAnalysis.CSharp to 2.2.0

### DIFF
--- a/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
+++ b/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
     <PackageReference Include="Validation" Version="2.4.13" />
   </ItemGroup>
 


### PR DESCRIPTION
I found that I'm unable to use C# 7.0 features such as `throw expression` or value tuples. If I update packages locally I'm unable to build solution due to fails in nuget dependency consolidation mechanism. So I propose to update your nuget up to date. It doesn't require any additional dependencies, doesn't require higher NetStandard, so I don't see any problems here.