### PR TITLE
Added Assembly Resolve

### DIFF
--- a/src/CodeGeneration.Roslyn.Tests.Generators/CodeGeneration.Roslyn.Tests.Generators.csproj
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/CodeGeneration.Roslyn.Tests.Generators.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
+++ b/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\opensource.snk</AssemblyOriginatorKeyFile>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
     <PackageReference Include="Validation" Version="2.4.13" />


### PR DESCRIPTION
Added logic to resolve referenced assemblies of generator assembly.

This should prevent problems with generators that uses other assemblies described in #61.

To use `DependencyContext` it was necessary to push target framework version to netstandard 1.6.