### PR TITLE
Assembly attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If you build with `dotnet build`, you need to take a couple extra steps. First, 
 Second, add this item to an `<ItemGroup>` in the project that will execute the code generator as part of your build:
 
 ```xml
-<DotNetCliToolReference Include="dotnet-codegen" Version="0.4.11" />
+<DotNetCliToolReference Include="dotnet-codegen" Version="0.4.12" />
 ```
 
 You should adjust the version in the above xml to match the version of this tool you are using.
@@ -187,10 +187,10 @@ to immediately see the effects of your changes on the generated code.
 You can also package up your code generator as a NuGet package for others to install
 and use. Your NuGet package should include a dependency on the `CodeGeneration.Roslyn.BuildTime`
 that matches the version of `CodeGeneration.Roslyn` that you used to produce your generator.
-For example, if you used version 0.4.11 of this project, your .nuspec file would include this tag:
+For example, if you used version 0.4.12 of this project, your .nuspec file would include this tag:
 
 ```xml
-<dependency id="CodeGeneration.Roslyn.BuildTime" version="0.4.11" />
+<dependency id="CodeGeneration.Roslyn.BuildTime" version="0.4.12" />
 ```
 
 In addition to this dependency, your NuGet package should include a `build` folder with an
@@ -219,7 +219,7 @@ so that the MSBuild Task can invoke the `dotnet codegen` command line tool:
 ```xml
 <ItemGroup>
   <PackageReference Include="YourCodeGenPackage" Version="1.2.3" PrivateAssets="all" />
-  <DotNetCliToolReference Include="dotnet-codegen" Version="0.4.11" />
+  <DotNetCliToolReference Include="dotnet-codegen" Version="0.4.12" />
 </ItemGroup>
 ```
 

--- a/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
+++ b/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
@@ -23,6 +23,9 @@ namespace CodeGeneration.Roslyn.Tasks
         public ITaskItem[] GeneratorAssemblySearchPaths { get; set; }
 
         [Required]
+        public string ProjectDirectory { get; set; }
+
+        [Required]
         public string IntermediateOutputDirectory { get; set; }
 
         public string ToolLocationOverride { get; set; }
@@ -79,6 +82,9 @@ namespace CodeGeneration.Roslyn.Tasks
 
             argBuilder.AppendLine("--out");
             argBuilder.AppendLine(this.IntermediateOutputDirectory);
+
+            argBuilder.AppendLine("--projectDir");
+            argBuilder.AppendLine(ProjectDirectory);
 
             this.generatedCompileItemsFilePath = Path.Combine(this.IntermediateOutputDirectory, Path.GetRandomFileName());
             argBuilder.AppendLine("--generatedFilesList");

--- a/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
+++ b/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
@@ -84,7 +84,7 @@ namespace CodeGeneration.Roslyn.Tasks
             argBuilder.AppendLine(this.IntermediateOutputDirectory);
 
             argBuilder.AppendLine("--projectDir");
-            argBuilder.AppendLine(ProjectDirectory);
+            argBuilder.AppendLine(this.ProjectDirectory);
 
             this.generatedCompileItemsFilePath = Path.Combine(this.IntermediateOutputDirectory, Path.GetRandomFileName());
             argBuilder.AppendLine("--generatedFilesList");

--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
@@ -19,6 +19,7 @@
   <Target Name="GenerateCodeFromAttributes" DependsOnTargets="ResolveReferences" BeforeTargets="CoreCompile">
     <GenerateCodeFromAttributes
       ToolLocationOverride="$(GenerateCodeFromAttributesToolPathOverride)"
+      ProjectDirectory="$(MSBuildProjectDirectory)"
       Compile="@(Compile)"
       ReferencePath="@(ReferencePath)"
       GeneratorAssemblySearchPaths="@(GeneratorAssemblySearchPaths)"

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathAttribute.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace CodeGeneration.Roslyn.Tests.Generators
+{
+    using System;
+    using System.Diagnostics;
+    using Validation;
+
+    [AttributeUsage(AttributeTargets.Assembly)]
+    [CodeGenerationAttribute(typeof(DirectoryPathGenerator))]
+    [Conditional("CodeGeneration")]
+    public class DirectoryPathAttribute : Attribute
+    {
+    }
+}

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+
+namespace CodeGeneration.Roslyn.Tests.Generators
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Validation;
+    using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+    public class DirectoryPathGenerator : ICodeGenerator
+    {
+        public DirectoryPathGenerator(AttributeData attributeData)
+        {
+            Requires.NotNull(attributeData, nameof(attributeData));
+        }
+
+        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
+        {
+            var results = SyntaxFactory.List<MemberDeclarationSyntax>();
+
+            var compilationUnitSyntax = (CompilationUnitSyntax) context.ProcessingMember;
+            MemberDeclarationSyntax copy = ClassDeclaration("DirectoryGenerationTest")
+                .AddMembers(
+                            FieldDeclaration(
+                                             VariableDeclaration(
+                                                                 PredefinedType(
+                                                                                Token(SyntaxKind.StringKeyword)))
+                                                 .AddVariables(
+                                                               VariableDeclarator(
+                                                                                  Identifier("S"))
+                                                                   .WithInitializer(
+                                                                                    EqualsValueClause(
+                                                                                                      LiteralExpression(
+                                                                                                                        SyntaxKind.StringLiteralExpression,
+                                                                                                                        Literal(context.ProjectDirectory))))))
+                                .WithModifiers(
+                                               TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.ConstKeyword))));
+
+            results = results.Add(copy);
+
+            return Task.FromResult(results);
+        }
+    }
+}

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
-using System;
-
 namespace CodeGeneration.Roslyn.Tests.Generators
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -22,29 +21,21 @@ namespace CodeGeneration.Roslyn.Tests.Generators
 
         public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
-            var results = SyntaxFactory.List<MemberDeclarationSyntax>();
-
-            var compilationUnitSyntax = (CompilationUnitSyntax) context.ProcessingMember;
-            MemberDeclarationSyntax copy = ClassDeclaration("DirectoryGenerationTest")
+            var member = ClassDeclaration("DirectoryGenerationTest")
                 .AddMembers(
-                            FieldDeclaration(
-                                             VariableDeclaration(
-                                                                 PredefinedType(
-                                                                                Token(SyntaxKind.StringKeyword)))
-                                                 .AddVariables(
-                                                               VariableDeclarator(
-                                                                                  Identifier("S"))
-                                                                   .WithInitializer(
-                                                                                    EqualsValueClause(
-                                                                                                      LiteralExpression(
-                                                                                                                        SyntaxKind.StringLiteralExpression,
-                                                                                                                        Literal(context.ProjectDirectory))))))
-                                .WithModifiers(
-                                               TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.ConstKeyword))));
+                    FieldDeclaration(
+                        VariableDeclaration(
+                            PredefinedType(Token(SyntaxKind.StringKeyword)))
+                        .AddVariables(
+                            VariableDeclarator(Identifier("S"))
+                            .WithInitializer(
+                                EqualsValueClause(
+                                    LiteralExpression(
+                                        SyntaxKind.StringLiteralExpression,
+                                        Literal(context.ProjectDirectory))))))
+                    .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.ConstKeyword))));
 
-            results = results.Add(copy);
-
-            return Task.FromResult(results);
+            return Task.FromResult(List<MemberDeclarationSyntax>(new []{member}));
         }
     }
 }

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
@@ -21,7 +21,7 @@ namespace CodeGeneration.Roslyn.Tests.Generators
 
         public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
-            var member = ClassDeclaration("DirectoryAttributeTest")
+            var member = ClassDeclaration("DirectoryPathTest")
                 .AddMembers(
                     FieldDeclaration(
                         VariableDeclaration(

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DirectoryPathGenerator.cs
@@ -21,13 +21,13 @@ namespace CodeGeneration.Roslyn.Tests.Generators
 
         public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
-            var member = ClassDeclaration("DirectoryGenerationTest")
+            var member = ClassDeclaration("DirectoryAttributeTest")
                 .AddMembers(
                     FieldDeclaration(
                         VariableDeclaration(
                             PredefinedType(Token(SyntaxKind.StringKeyword)))
                         .AddVariables(
-                            VariableDeclarator(Identifier("S"))
+                            VariableDeclarator(Identifier("Path"))
                             .WithInitializer(
                                 EqualsValueClause(
                                     LiteralExpression(

--- a/src/CodeGeneration.Roslyn.Tests.Generators/DuplicateWithSuffixGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/DuplicateWithSuffixGenerator.cs
@@ -35,7 +35,7 @@ namespace CodeGeneration.Roslyn.Tests.Generators
             var results = SyntaxFactory.List<MemberDeclarationSyntax>();
 
             MemberDeclarationSyntax copy = null;
-            var applyToClass = context.ProcessingMember as ClassDeclarationSyntax;
+            var applyToClass = context.ProcessingNode as ClassDeclarationSyntax;
             if (applyToClass != null)
             {
                 copy = applyToClass

--- a/src/CodeGeneration.Roslyn.Tests.Generators/MultiplySuffixGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/MultiplySuffixGenerator.cs
@@ -29,7 +29,7 @@ namespace CodeGeneration.Roslyn.Tests.Generators
             var results = SyntaxFactory.List<MemberDeclarationSyntax>();
 
             MemberDeclarationSyntax copy = null;
-            var applyToClass = context.ProcessingMember as ClassDeclarationSyntax;
+            var applyToClass = context.ProcessingNode as ClassDeclarationSyntax;
             if (applyToClass != null)
             {
                 var properties = applyToClass.Members.OfType<PropertyDeclarationSyntax>()

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -19,7 +19,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
-        Assert.NotNull(DirectoryGenerationTest.S);
+        Assert.True(DirectoryAttributeTest.Path.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests"));
     }
 
     [DuplicateWithSuffixByName("A")]

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -19,7 +19,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
-        Assert.True(DirectoryAttributeTest.Path.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests"));
+        Assert.True(DirectoryPathTest.Path.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests"));
     }
 
     [DuplicateWithSuffixByName("A")]

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -20,7 +20,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
-        Assert.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests", DirectoryPathTest.Path, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(@"src\CodeGeneration.Roslyn.Tests", DirectoryPathTest.Path, StringComparison.OrdinalIgnoreCase);
     }
 
     [DuplicateWithSuffixByName("A")]

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using CodeGeneration.Roslyn.Tests.Generators;
 using Xunit;
+
+[assembly: DirectoryPath]
 
 public partial class CodeGenerationTests
 {
@@ -21,6 +19,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
+        Assert.NotNull(DirectoryGenerationTest.S);
     }
 
     [DuplicateWithSuffixByName("A")]

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
+using System;
 using CodeGeneration.Roslyn.Tests.Generators;
 using Xunit;
 
@@ -19,7 +20,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
-        Assert.True(DirectoryPathTest.Path.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests"));
+        Assert.EndsWith(@"CodeGeneration.Roslyn\src\CodeGeneration.Roslyn.Tests", DirectoryPathTest.Path, StringComparison.OrdinalIgnoreCase);
     }
 
     [DuplicateWithSuffixByName("A")]

--- a/src/CodeGeneration.Roslyn.Tool/Program.cs
+++ b/src/CodeGeneration.Roslyn.Tool/Program.cs
@@ -18,11 +18,13 @@ namespace CodeGeneration.Roslyn.Generate
             IReadOnlyList<string> generatorSearchPaths = Array.Empty<string>();
             string generatedCompileItemFile = null;
             string outputDirectory = null;
+            string projectDir = null;
             ArgumentSyntax.Parse(args, syntax =>
             {
                 syntax.DefineOptionList("r|reference", ref refs, "Paths to assemblies being referenced");
                 syntax.DefineOptionList("generatorSearchPath", ref generatorSearchPaths, "Paths to folders that may contain generator assemblies");
                 syntax.DefineOption("out", ref outputDirectory, true, "The directory to write generated source files to");
+                syntax.DefineOption("projectDir", ref projectDir, true, "The absolute path of the directory where the project file is located");
                 syntax.DefineOption("generatedFilesList", ref generatedCompileItemFile, "The path to the file to create with a list of generated source files");
                 syntax.DefineParameterList("compile", ref compile, "Source files included in compilation");
             });
@@ -41,6 +43,7 @@ namespace CodeGeneration.Roslyn.Generate
 
             var generator = new CompilationGenerator
             {
+                ProjectDirectory = projectDir,
                 Compile = compile,
                 ReferencePath = refs,
                 GeneratorAssemblySearchPaths = generatorSearchPaths,

--- a/src/CodeGeneration.Roslyn/CompilationGenerator.cs
+++ b/src/CodeGeneration.Roslyn/CompilationGenerator.cs
@@ -65,6 +65,8 @@ namespace CodeGeneration.Roslyn
         /// </summary>
         public IEnumerable<string> EmptyGeneratedFiles => this.emptyGeneratedFiles;
 
+        public string ProjectDirectory { get; set; }
+
         public void Generate(IProgress<Diagnostic> progress = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Verify.Operation(this.Compile != null, $"{nameof(Compile)} must be set first.");
@@ -104,6 +106,7 @@ namespace CodeGeneration.Roslyn
                                 var generatedSyntaxTree = DocumentTransform.TransformAsync(
                                     compilation,
                                     inputSyntaxTree,
+                                    ProjectDirectory,
                                     this.LoadAssembly,
                                     progress).GetAwaiter().GetResult();
 

--- a/src/CodeGeneration.Roslyn/CompilationGenerator.cs
+++ b/src/CodeGeneration.Roslyn/CompilationGenerator.cs
@@ -106,7 +106,7 @@ namespace CodeGeneration.Roslyn
                                 var generatedSyntaxTree = DocumentTransform.TransformAsync(
                                     compilation,
                                     inputSyntaxTree,
-                                    ProjectDirectory,
+                                    this.ProjectDirectory,
                                     this.LoadAssembly,
                                     progress).GetAwaiter().GetResult();
 

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -114,18 +114,12 @@ namespace CodeGeneration.Roslyn
             return compilationUnit.SyntaxTree;
         }
 
-        private static ImmutableArray<AttributeData>? GetAttributeData(CSharpCompilation compilation, SemanticModel document, CSharpSyntaxNode memberNode)
+        private static ImmutableArray<AttributeData>? GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode memberNode)
         {
             switch (memberNode)
             {
                 case CompilationUnitSyntax syntax:
-                    var validAttributesName = syntax.AttributeLists
-                                                    .SelectMany(x => x.Attributes)
-                                                    .Select(x => (x.Name as IdentifierNameSyntax)?.Identifier.ValueText)
-                                                    .Where(x => x != null)
-                                                    .Select(x => x.EndsWith("Attribute") ? x : x + "Attribute")
-                                                    .ToImmutableHashSet();
-                    return compilation.Assembly.GetAttributes().Where(x => validAttributesName.Contains(x.AttributeClass.MetadataName)).ToImmutableArray();
+                    return compilation.Assembly.GetAttributes().Where(x => x.ApplicationSyntaxReference.SyntaxTree == syntax.SyntaxTree).ToImmutableArray();
                 default:
                     return document.GetDeclaredSymbol(memberNode)?.GetAttributes();
             }

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -56,10 +56,7 @@ namespace CodeGeneration.Roslyn
             foreach (var memberNode in memberNodes)
             {
                 var attributeData = GetAttributeData(compilation, inputSemanticModel, memberNode);
-                if (attributeData == null)
-                    continue;
-
-                var generators = FindCodeGenerators(attributeData.Value, assemblyLoader);
+                var generators = FindCodeGenerators(attributeData, assemblyLoader);
                 foreach (var generator in generators)
                 {
                     var context = new TransformationContext(memberNode, inputSemanticModel, compilation, projectDirectory);
@@ -114,7 +111,7 @@ namespace CodeGeneration.Roslyn
             return compilationUnit.SyntaxTree;
         }
 
-        private static ImmutableArray<AttributeData>? GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode memberNode)
+        private static ImmutableArray<AttributeData> GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode memberNode)
         {
             Requires.NotNull(document, nameof(document));
             Requires.NotNull(memberNode, nameof(memberNode));
@@ -124,7 +121,7 @@ namespace CodeGeneration.Roslyn
                 case CompilationUnitSyntax syntax:
                     return compilation.Assembly.GetAttributes().Where(x => x.ApplicationSyntaxReference.SyntaxTree == syntax.SyntaxTree).ToImmutableArray();
                 default:
-                    return document.GetDeclaredSymbol(memberNode)?.GetAttributes();
+                    return document.GetDeclaredSymbol(memberNode)?.GetAttributes() ?? ImmutableArray<AttributeData>.Empty;
             }
         }
 

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -116,6 +116,9 @@ namespace CodeGeneration.Roslyn
 
         private static ImmutableArray<AttributeData>? GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode memberNode)
         {
+            Requires.NotNull(document, nameof(document));
+            Requires.NotNull(memberNode, nameof(memberNode));
+
             switch (memberNode)
             {
                 case CompilationUnitSyntax syntax:

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -50,7 +50,7 @@ namespace CodeGeneration.Roslyn
 
             var inputFileLevelUsingDirectives = inputSyntaxTree.GetRoot().ChildNodes().OfType<UsingDirectiveSyntax>();
 
-            var memberNodes = inputSyntaxTree.GetRoot().DescendantNodesAndSelf().OfType<CSharpSyntaxNode>();
+            var memberNodes = inputSyntaxTree.GetRoot().DescendantNodesAndSelf(n => n is CompilationUnitSyntax || n is NamespaceDeclarationSyntax || n is TypeDeclarationSyntax).OfType<CSharpSyntaxNode>();
 
             var emittedMembers = SyntaxFactory.List<MemberDeclarationSyntax>();
             foreach (var memberNode in memberNodes)

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -5,13 +5,12 @@ namespace CodeGeneration.Roslyn
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
+    using System.Collections.Immutable;
     using System.Linq;
     using System.Reflection;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -40,7 +39,7 @@ namespace CodeGeneration.Roslyn
         /// <param name="assemblyLoader">A function that can load an assembly with the given name.</param>
         /// <param name="progress">Reports warnings and errors in code generation.</param>
         /// <returns>A task whose result is the generated document.</returns>
-        public static async Task<SyntaxTree> TransformAsync(CSharpCompilation compilation, SyntaxTree inputDocument, Func<AssemblyName, Assembly> assemblyLoader, IProgress<Diagnostic> progress)
+        public static async Task<SyntaxTree> TransformAsync(CSharpCompilation compilation, SyntaxTree inputDocument, string projectDirectory, Func<AssemblyName, Assembly> assemblyLoader, IProgress<Diagnostic> progress)
         {
             Requires.NotNull(compilation, nameof(compilation));
             Requires.NotNull(inputDocument, nameof(inputDocument));
@@ -51,16 +50,19 @@ namespace CodeGeneration.Roslyn
 
             var inputFileLevelUsingDirectives = inputSyntaxTree.GetRoot().ChildNodes().OfType<UsingDirectiveSyntax>();
 
-            var memberNodes = from syntax in inputSyntaxTree.GetRoot().DescendantNodes(n => n is CompilationUnitSyntax || n is NamespaceDeclarationSyntax || n is TypeDeclarationSyntax).OfType<MemberDeclarationSyntax>()
-                              select syntax;
+            var memberNodes = inputSyntaxTree.GetRoot().DescendantNodesAndSelf().OfType<CSharpSyntaxNode>();
 
             var emittedMembers = SyntaxFactory.List<MemberDeclarationSyntax>();
             foreach (var memberNode in memberNodes)
             {
-                var generators = FindCodeGenerators(inputSemanticModel, memberNode, assemblyLoader);
+                var attributeData = GetAttributeData(compilation, inputSemanticModel, memberNode);
+                if (attributeData == null)
+                    continue;
+
+                var generators = FindCodeGenerators(attributeData.Value, assemblyLoader);
                 foreach (var generator in generators)
                 {
-                    var context = new TransformationContext(memberNode, inputSemanticModel, compilation);
+                    var context = new TransformationContext(memberNode, inputSemanticModel, compilation, projectDirectory);
                     var generatedTypes = await generator.GenerateAsync(context, progress, CancellationToken.None);
 
                     // Figure out ancestry for the generated type, including nesting types and namespaces.
@@ -112,22 +114,32 @@ namespace CodeGeneration.Roslyn
             return compilationUnit.SyntaxTree;
         }
 
-        private static IEnumerable<ICodeGenerator> FindCodeGenerators(SemanticModel document, SyntaxNode nodeWithAttributesApplied, Func<AssemblyName, Assembly> assemblyLoader)
+        private static ImmutableArray<AttributeData>? GetAttributeData(CSharpCompilation compilation, SemanticModel document, CSharpSyntaxNode memberNode)
         {
-            Requires.NotNull(document, "document");
-            Requires.NotNull(nodeWithAttributesApplied, "nodeWithAttributesApplied");
-
-            var symbol = document.GetDeclaredSymbol(nodeWithAttributesApplied);
-            if (symbol != null)
+            switch (memberNode)
             {
-                foreach (var attributeData in symbol.GetAttributes())
+                case CompilationUnitSyntax syntax:
+                    var validAttributesName = syntax.AttributeLists
+                                                    .SelectMany(x => x.Attributes)
+                                                    .Select(x => (x.Name as IdentifierNameSyntax)?.Identifier.ValueText)
+                                                    .Where(x => x != null)
+                                                    .Select(x => x.EndsWith("Attribute") ? x : x + "Attribute")
+                                                    .ToImmutableHashSet();
+                    return compilation.Assembly.GetAttributes().Where(x => validAttributesName.Contains(x.AttributeClass.MetadataName)).ToImmutableArray();
+                default:
+                    return document.GetDeclaredSymbol(memberNode)?.GetAttributes();
+            }
+        }
+
+        private static IEnumerable<ICodeGenerator> FindCodeGenerators(ImmutableArray<AttributeData> nodeAttributes, Func<AssemblyName, Assembly> assemblyLoader)
+        {
+            foreach (var attributeData in nodeAttributes)
+            {
+                Type generatorType = GetCodeGeneratorTypeForAttribute(attributeData.AttributeClass, assemblyLoader);
+                if (generatorType != null)
                 {
-                    Type generatorType = GetCodeGeneratorTypeForAttribute(attributeData.AttributeClass, assemblyLoader);
-                    if (generatorType != null)
-                    {
-                        ICodeGenerator generator = (ICodeGenerator)Activator.CreateInstance(generatorType, attributeData);
-                        yield return generator;
-                    }
+                    ICodeGenerator generator = (ICodeGenerator)Activator.CreateInstance(generatorType, attributeData);
+                    yield return generator;
                 }
             }
         }

--- a/src/CodeGeneration.Roslyn/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn/DocumentTransform.cs
@@ -111,17 +111,17 @@ namespace CodeGeneration.Roslyn
             return compilationUnit.SyntaxTree;
         }
 
-        private static ImmutableArray<AttributeData> GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode memberNode)
+        private static ImmutableArray<AttributeData> GetAttributeData(Compilation compilation, SemanticModel document, SyntaxNode syntaxNode)
         {
             Requires.NotNull(document, nameof(document));
-            Requires.NotNull(memberNode, nameof(memberNode));
+            Requires.NotNull(syntaxNode, nameof(syntaxNode));
 
-            switch (memberNode)
+            switch (syntaxNode)
             {
                 case CompilationUnitSyntax syntax:
                     return compilation.Assembly.GetAttributes().Where(x => x.ApplicationSyntaxReference.SyntaxTree == syntax.SyntaxTree).ToImmutableArray();
                 default:
-                    return document.GetDeclaredSymbol(memberNode)?.GetAttributes() ?? ImmutableArray<AttributeData>.Empty;
+                    return document.GetDeclaredSymbol(syntaxNode)?.GetAttributes() ?? ImmutableArray<AttributeData>.Empty;
             }
         }
 

--- a/src/CodeGeneration.Roslyn/TransformationContext.cs
+++ b/src/CodeGeneration.Roslyn/TransformationContext.cs
@@ -8,21 +8,21 @@ namespace CodeGeneration.Roslyn
         /// <summary>
         /// Initializes a new instance of the <see cref="TransformationContext" /> class.
         /// </summary>
-        /// <param name="processingMember">The syntax node the generator attribute is found on.</param>
+        /// <param name="processingNode">The syntax node the generator attribute is found on.</param>
         /// <param name="semanticModel">The semantic model.</param>
         /// <param name="compilation">The overall compilation being generated for.</param>
         /// <param name="projectDirectory">The absolute path of the directory where the project file is located</param>
-        public TransformationContext(CSharpSyntaxNode processingMember, SemanticModel semanticModel, CSharpCompilation compilation,
+        public TransformationContext(CSharpSyntaxNode processingNode, SemanticModel semanticModel, CSharpCompilation compilation,
                                      string projectDirectory)
         {
-            ProcessingMember = processingMember;
+            ProcessingNode = processingNode;
             SemanticModel = semanticModel;
             Compilation = compilation;
             ProjectDirectory = projectDirectory;
         }
 
         /// <summary>Gets the syntax node the generator attribute is found on.</summary>
-        public CSharpSyntaxNode ProcessingMember { get; }
+        public CSharpSyntaxNode ProcessingNode { get; }
 
         /// <summary>Gets the semantic model for the <see cref="Compilation" />.</summary>
         public SemanticModel SemanticModel { get; }

--- a/src/CodeGeneration.Roslyn/TransformationContext.cs
+++ b/src/CodeGeneration.Roslyn/TransformationContext.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CodeGeneration.Roslyn
 {
@@ -13,20 +11,28 @@ namespace CodeGeneration.Roslyn
         /// <param name="processingMember">The syntax node the generator attribute is found on.</param>
         /// <param name="semanticModel">The semantic model.</param>
         /// <param name="compilation">The overall compilation being generated for.</param>
-        public TransformationContext(MemberDeclarationSyntax processingMember, SemanticModel semanticModel, CSharpCompilation compilation)
+        /// <param name="projectDirectory">The absolute path of the directory where the project file is located</param>
+        public TransformationContext(CSharpSyntaxNode processingMember, SemanticModel semanticModel, CSharpCompilation compilation,
+                                     string projectDirectory)
         {
             ProcessingMember = processingMember;
             SemanticModel = semanticModel;
             Compilation = compilation;
+            ProjectDirectory = projectDirectory;
         }
 
         /// <summary>Gets the syntax node the generator attribute is found on.</summary>
-        public MemberDeclarationSyntax ProcessingMember { get; }
+        public CSharpSyntaxNode ProcessingMember { get; }
 
         /// <summary>Gets the semantic model for the <see cref="Compilation" />.</summary>
         public SemanticModel SemanticModel { get; }
 
         /// <summary>Gets the overall compilation being generated for.</summary>
         public CSharpCompilation Compilation { get; }
+
+        /// <summary>
+        /// Gets the absolute path of the directory where the project file is located
+        /// </summary>
+        public string ProjectDirectory { get; }
     }
 }


### PR DESCRIPTION
This is an attempt to provide generation for a global attribute which have no type to sit on. 

It also adds `ProjectDirectory` attribute because if attributes have no type to interact it should still have some way to get information about project. This guy should fix #66 because with knowlenge of project directory I can recursively get all needed files and transform them as I need. Test example just creates a const public field with path to the `csproj`, however, actual code generator may use it to list all `.myextension` files and use them to create an output.