### PR TITLE
Logger

### DIFF
--- a/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
+++ b/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
@@ -103,16 +103,26 @@ namespace CodeGeneration.Roslyn.Tasks
         {
             MessageImportance newImportance;
             if (DidExtractPrefix("High"))
+            {
                 newImportance = MessageImportance.High;
+            }
             else if (DidExtractPrefix("Normal"))
+            {
                 newImportance = MessageImportance.Normal;
+            }
             else if (DidExtractPrefix("Low"))
+            {
                 newImportance = MessageImportance.Low;
+            }
             else
+            {
                 newImportance = messageImportance;
+            }
 
             if (newImportance < messageImportance)
+            {
                 messageImportance = newImportance; // Lower value => higher importance
+            }
 
             base.LogEventsFromTextOutput(singleLine, messageImportance);
 

--- a/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
+++ b/src/CodeGeneration.Roslyn.Tasks/GenerateCodeFromAttributes.cs
@@ -91,12 +91,41 @@ namespace CodeGeneration.Roslyn.Tasks
             argBuilder.AppendLine(this.generatedCompileItemsFilePath);
 
             argBuilder.AppendLine("--");
-            foreach(var item in this.Compile)
+            foreach (var item in this.Compile)
             {
                 argBuilder.AppendLine(item.ItemSpec);
             }
 
             return argBuilder.ToString();
+        }
+
+        protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+        {
+            MessageImportance newImportance;
+            if (DidExtractPrefix("High"))
+                newImportance = MessageImportance.High;
+            else if (DidExtractPrefix("Normal"))
+                newImportance = MessageImportance.Normal;
+            else if (DidExtractPrefix("Low"))
+                newImportance = MessageImportance.Low;
+            else
+                newImportance = messageImportance;
+
+            if (newImportance < messageImportance)
+                messageImportance = newImportance; // Lower value => higher importance
+
+            base.LogEventsFromTextOutput(singleLine, messageImportance);
+
+            bool DidExtractPrefix(string importanceString)
+            {
+                var prefix = $"::{importanceString}::";
+                if (singleLine.StartsWith(prefix))
+                {
+                    singleLine = singleLine.Substring(prefix.Length);
+                    return true;
+                }
+                return false;
+            }
         }
     }
 }

--- a/src/CodeGeneration.Roslyn.Tool/Program.cs
+++ b/src/CodeGeneration.Roslyn.Tool/Program.cs
@@ -53,8 +53,10 @@ namespace CodeGeneration.Roslyn.Generate
             {
                 generator.Generate(progress);
             }
-            catch
+            catch (Exception e)
             {
+                Logger.Log(LogLevel.High, $"{e.Message}: {e.Message}");
+                Logger.Log(LogLevel.High, e.ToString());
                 return 3;
             }
 
@@ -65,7 +67,7 @@ namespace CodeGeneration.Roslyn.Generate
 
             foreach (var file in generator.GeneratedFiles)
             {
-                Console.WriteLine(file);
+                Logger.Log(LogLevel.Normal, file);
             }
 
             return 0;

--- a/src/CodeGeneration.Roslyn.Tool/Program.cs
+++ b/src/CodeGeneration.Roslyn.Tool/Program.cs
@@ -55,7 +55,7 @@ namespace CodeGeneration.Roslyn.Generate
             }
             catch (Exception e)
             {
-                Logger.Log(LogLevel.High, $"{e.Message}: {e.Message}");
+                Logger.Log(LogLevel.High, $"{e.GetType().Name}: {e.Message}");
                 Logger.Log(LogLevel.High, e.ToString());
                 return 3;
             }

--- a/src/CodeGeneration.Roslyn/Logger.cs
+++ b/src/CodeGeneration.Roslyn/Logger.cs
@@ -19,8 +19,7 @@ namespace CodeGeneration.Roslyn
         /// <summary>
         /// Low importance, appears in more verbose logs
         /// </summary>
-        Low = 2
-
+        Low = 2,
     }
     public static class Logger
     {

--- a/src/CodeGeneration.Roslyn/Logger.cs
+++ b/src/CodeGeneration.Roslyn/Logger.cs
@@ -37,7 +37,7 @@ namespace CodeGeneration.Roslyn
                 Print(message.Substring(begin, end - begin));
                 begin = end + (foundR ? 2 : 1);
                 end = message.IndexOf('\n', begin);
-                bool foundR = end > 0 && message[end - 1] == '\r';
+                foundR = end > 0 && message[end - 1] == '\r';
                 if(foundR)
                     end--;
             }

--- a/src/CodeGeneration.Roslyn/Logger.cs
+++ b/src/CodeGeneration.Roslyn/Logger.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CodeGeneration.Roslyn
+{
+    public enum LogLevel
+    {
+        /// <summary>
+        /// High importance, appears in less verbose logs
+        /// </summary>
+        High = 0,
+
+        /// <summary>
+        /// Normal importance
+        /// </summary>
+        Normal = 1,
+
+        /// <summary>
+        /// Low importance, appears in more verbose logs
+        /// </summary>
+        Low = 2
+
+    }
+    public static class Logger
+    {
+        public static void Log(LogLevel logLevel, string message)
+        {
+            // Prefix every Line with loglevel
+            var begin = 0;
+            var end = message.IndexOf('\n');
+            while (end != -1)
+            {
+                Print(message.Substring(begin, end - begin));
+                begin = end;
+                end = message.IndexOf('\n', begin);
+            }
+            Print(message.Substring(begin, message.Length - begin));
+
+            void Print(string toPrint) => Console.WriteLine($"::{logLevel}::{toPrint}");
+        }
+    }
+}

--- a/src/CodeGeneration.Roslyn/Logger.cs
+++ b/src/CodeGeneration.Roslyn/Logger.cs
@@ -29,11 +29,17 @@ namespace CodeGeneration.Roslyn
             // Prefix every Line with loglevel
             var begin = 0;
             var end = message.IndexOf('\n');
+            bool foundR = end > 0 && message[end - 1] == '\r';
+            if(foundR)
+                end--;
             while (end != -1)
             {
                 Print(message.Substring(begin, end - begin));
-                begin = end;
+                begin = end + (foundR ? 2 : 1);
                 end = message.IndexOf('\n', begin);
+                bool foundR = end > 0 && message[end - 1] == '\r';
+                if(foundR)
+                    end--;
             }
             Print(message.Substring(begin, message.Length - begin));
 


### PR DESCRIPTION
When I was debugging (while building in VS) this framework, I had sometimes an bug which threw an exception. This was cached and an return code of 3 was the result.

Also different Console.Writeline were not shown. I Could have probably raised the output level of the build to verbose or even diagnostic, but this generates to much noise.


I have added a Logging class that allows to Log text at different loglevels to the build output.
In addition when returning a result of 3 now the exception will be logged to the output with highest log level.
