### PR TITLE
Update Roslyn version to 2.9.0, require exact in NuGet

### DIFF
--- a/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynNugetVersion)" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Xunit" Version="2.3.1" />
     <PackageReference Include="Xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
+++ b/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[$(RoslynNugetVersion)]" />
     <PackageReference Include="Validation" Version="2.4.13" />
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,6 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <IsPackable Condition=" $(MSBuildProjectName.Contains('Test')) ">false</IsPackable>
     <NerdbankGitVersioningVersion>2.2.13</NerdbankGitVersioningVersion>
+    <RoslynNugetVersion>2.9.0</RoslynNugetVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`Directory.Build.props` gained `RoslynNugetVersion` with ~~`2.*`~~ `2.9.0` value ~~to always depend on latest Roslyn.~~

`CodeGeneration.Roslyn` has strict dependency on this version: `Version="[$(RoslynNugetVersion)]"`

Closes #77