### PR TITLE
Fix tests

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -57,7 +57,7 @@ jobs:
     inputs:
       command: test
       workingDirectory: src
-      nobuild: true
+      arguments: -v n --no-build -c $(BuildConfiguration)
 
   - task: CopyFiles@1
     displayName: Collecting project.assets.json artifacts

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -20,6 +20,7 @@ jobs:
   pool: Hosted VS2017
   steps:
   - task: DotNetCoreInstaller@0
+    displayName: Install/select .NET Core SDK
     inputs:
       version: '2.1.500'
 
@@ -42,52 +43,52 @@ jobs:
       nugetConfigPath: src/nuget.config
 
   # Use VSBuild on Windows so GitLink will work (it fails on dotnet build)
+  # Also targeting net20, net40, PCLs etc requires full MSBuild
   - task: VSBuild@1
+    displayName: Build Visual Studio solution
     inputs:
       vsVersion: 15.0
       msbuildArgs: /t:build,pack /m /v:m /bl:"$(Build.ArtifactStagingDirectory)/build_logs/msbuild.binlog"
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-    displayName: Build Visual Studio solution
 
   - task: DotNetCoreCLI@2
+    displayName: Run tests
     inputs:
       command: test
-      projects: src/CodeGeneration.Roslyn.Tests
-      configuration: $(BuildConfiguration)
+      workingDirectory: src
       nobuild: true
-    continueOnError: true  # Tests fail right now.
 
   - task: CopyFiles@1
+    displayName: Collecting project.assets.json artifacts
     inputs:
       Contents: |
         obj/**/project.assets.json
       TargetFolder: $(Build.ArtifactStagingDirectory)/projectAssetsJson
-    displayName: Collecting project.assets.json artifacts
     condition: succeededOrFailed()
 
   - task: CopyFiles@1
+    displayName: Collecting deployables
     inputs:
       Contents: |
         bin/**/$(BuildConfiguration)/**/*.nupkg
       TargetFolder: $(Build.ArtifactStagingDirectory)/deployables
       flattenFolders: true
-    displayName: Collecting deployables
 
   - task: PublishBuildArtifacts@1
+    displayName: Publish projectAssetsJson artifacts
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/projectAssetsJson
       ArtifactName: projectAssetsJson
       ArtifactType: Container
-    displayName: Publish projectAssetsJson artifacts
     condition: and(succeededOrFailed(), ne(variables['system.pullrequest.isfork'], true))
 
   - task: PublishBuildArtifacts@1
+    displayName: Publish build_logs artifacts
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
       ArtifactName: build_logs
       ArtifactType: Container
-    displayName: Publish build_logs artifacts
     condition: and(succeededOrFailed(), ne(variables['system.pullrequest.isfork'], true))
 
   ## The rest of these steps are for deployment and skipped for PR builds
@@ -100,11 +101,11 @@ jobs:
   #  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['system.pullrequest.isfork'], true))
 
   - task: PublishBuildArtifacts@1
+    displayName: Publish deployables artifacts
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/deployables
       ArtifactName: deployables
       ArtifactType: Container
-    displayName: Publish deployables artifacts
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['system.pullrequest.isfork'], true))
 
 - job: Linux

--- a/azure-pipelines/testfx.yml
+++ b/azure-pipelines/testfx.yml
@@ -3,9 +3,8 @@ steps:
   displayName: Restore packages
   workingDirectory: ${{ parameters.projectdirectory }}
 - script: dotnet build -v n -f netcoreapp2.1 -c $(BuildConfiguration) --no-restore /bl:"$(Build.ArtifactStagingDirectory)/build_logs/netcoreapp2.1.binlog" -p:GitLinkEnabled=false
-  displayName: Build test for netcoreapp2.1
+  displayName: Build tests for netcoreapp2.1
   workingDirectory: ${{ parameters.projectdirectory }}
 - script: dotnet test -v n -f netcoreapp2.1 -c $(BuildConfiguration) --no-build
   displayName: Run tests for netcoreapp2.1
   workingDirectory: ${{ parameters.projectdirectory }}
-  continueOnError: true  # Tests fail right now.

--- a/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
@@ -12,10 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynNugetVersion)" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="Xunit" Version="2.3.1" />
-    <PackageReference Include="Xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGenerationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MS-PL license. See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.IO;
 using CodeGeneration.Roslyn.Tests.Generators;
 using Xunit;
 
@@ -20,7 +21,7 @@ public partial class CodeGenerationTests
         var fooB = new CodeGenerationTests.FooB();
         var multiplied = new MultipliedBar();
         multiplied.ValueSuff1020();
-        Assert.EndsWith(@"src\CodeGeneration.Roslyn.Tests", DirectoryPathTest.Path, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(Path.Combine("src", "CodeGeneration.Roslyn.Tests"), DirectoryPathTest.Path, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/CodeGeneration.Roslyn.Tests/Helpers/CompilationTestsBase.cs
+++ b/src/CodeGeneration.Roslyn.Tests/Helpers/CompilationTestsBase.cs
@@ -25,6 +25,9 @@ public abstract class CompilationTestsBase
             "mscorlib.dll",
             "System.dll",
             "System.Core.dll",
+#if NETCOREAPP
+            "System.Private.CoreLib.dll",
+#endif
             "System.Runtime.dll",
         };
         var coreMetaReferences =

--- a/src/CodeGeneration.Roslyn.sln
+++ b/src/CodeGeneration.Roslyn.sln
@@ -11,7 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CodeGeneration.Roslyn.Tests.ruleset = CodeGeneration.Roslyn.Tests.ruleset
 		..\CONTRIBUTION.md = ..\CONTRIBUTION.md
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 		..\LICENSE.txt = ..\LICENSE.txt
 		nuget.config = nuget.config

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,23 +15,23 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <WarningsAsErrors Condition=" '$(Configuration)' == Release ">true</WarningsAsErrors>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)/../obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
-    <OutputPath>$(MSBuildThisFileDirectory)/../bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
-    <PackageOutputPath>$(MSBuildThisFileDirectory)/../bin/Packages/$(Configuration)/</PackageOutputPath>
-    <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)../obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)../bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)../bin/Packages/$(Configuration)/</PackageOutputPath>
+    <IsTestingOnlyProject>$(MSBuildProjectName.Contains('Test'))</IsTestingOnlyProject>
     <RoslynNugetVersion>2.9.0</RoslynNugetVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" !$(IsTestProject) ">
+  <PropertyGroup Condition=" !$(IsTestingOnlyProject) ">
     <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/opensource.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/CodeGeneration.Roslyn.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $(IsTestProject) ">
+  <PropertyGroup Condition=" $(IsTestingOnlyProject) ">
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsPackable>false</IsPackable>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/CodeGeneration.Roslyn.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeGeneration.Roslyn.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)/stylecop.json">
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json">
       <Visible>false</Visible>
     </AdditionalFiles>
   </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Roslyn can't really sign assemblies on .NET Core -->
-    <PublicSign Condition=" '$(SignAssembly)' == 'true' and '$(MSBuildRuntimeType)' == 'Core' ">true</PublicSign>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
There was a problem on `netcoreapp2.1` fx because one fx reference was missing for .NET Core app: `System.Private.CoreLib.dll`.

Adding the reference fixes running tests, so I've reenabled failing on them for cloud builds.