### PR TITLE
Target netstandard2.0 and use Roslyn 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,27 @@ your code generation attribute is applied to, but with a suffix appended to its 
 
 ### Prerequisites
 
-* .NET Core SDK v2.x
+* [.NET Core SDK v2.1+][dotnet-sdk-2.1]
   
-  If you don't have v2.x there will be cryptic error messages
+  If you don't have v2.1+ there will be cryptic error messages
   (see [#111](https://github.com/AArnott/CodeGeneration.Roslyn/issues/111)).
 
 * .NET Core SDK v2.1.500 specifically for building this project
 
+[dotnet-sdk-2.1]: https://dotnet.microsoft.com/download/dotnet-core/2.1
+
 ### Define code generator
 [Define code generator]: #define-code-generator
 
-This must be done in a library that targets netstandard1.6 or net461 (or later;
-net461 is supported if you have .NET Core SDK v2.0+ installed, [see docs for details][netstandard-table]).
+This must be done in a library that targets `netstandard2.0` or `net461`
+(or any `netcoreapp2.1`-compatible target).
 Your generator cannot be defined in the same project that will have code generated
 for it because code generation runs *before* the receiving project is itself compiled.
 
 Install the [CodeGeneration.Roslyn][NuPkg] NuGet Package.
 
-Define the generator class (*note: constructor accepting `AttributeData` parameter is required*):
+Define the generator class in a class library targeting `netstandard2.0`
+(*note: constructor accepting `AttributeData` parameter is required*):
 
 ```csharp
 using CodeGeneration.Roslyn;
@@ -86,7 +89,7 @@ public class DuplicateWithSuffixGenerator : ICodeGenerator
 To activate your code generator, you need to define an attribute that can be
 applied to the class to be copied. This attribute may be defined in the same
 assembly as defines your code generator, but since your code generator must
-be defined in a netstandard1.6+ or net461+ library, this may limit which projects
+be defined in a `netcoreapp2.1`-compatible library, this may limit which projects
 can apply your attribute. So define your attribute in another assembly if
 it must be applied to projects that target older platforms.
 
@@ -95,7 +98,7 @@ If your attributes are in their own project, you must install the
 
 Define your attribute class.
 For this walkthrough, we will assume that the attributes are defined in the same
-netstandard1.6 project that defines the generator which allows us to use the more
+netstandard2.0 project that defines the generator which allows us to use the more
 convenient `typeof` syntax when declaring the code generator type.
 If the attributes and code generator classes were in separate assemblies, you must
 specify the assembly-qualified name of the generator type as a string instead.

--- a/src/CodeGeneration.Roslyn.Engine/CodeGeneration.Roslyn.Engine.csproj
+++ b/src/CodeGeneration.Roslyn.Engine/CodeGeneration.Roslyn.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>The engine of source code generation used by `dotnet-codegen` tool.</Description>
   </PropertyGroup>
 

--- a/src/CodeGeneration.Roslyn.Tests.Generators.Dependency/CodeGeneration.Roslyn.Tests.Generators.Dependency.csproj
+++ b/src/CodeGeneration.Roslyn.Tests.Generators.Dependency/CodeGeneration.Roslyn.Tests.Generators.Dependency.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 
 </Project>

--- a/src/CodeGeneration.Roslyn.Tests.Generators/CodeGeneration.Roslyn.Tests.Generators.csproj
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/CodeGeneration.Roslyn.Tests.Generators.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
-    <GenerateCodeFromAttributesToolPathOverride>$(OutputPath)..\..\CodeGeneration.Roslyn.Tool\$(Configuration)\netcoreapp2.0\dotnet-codegen.dll</GenerateCodeFromAttributesToolPathOverride>
+    <GenerateCodeFromAttributesToolPathOverride>$(OutputPath)..\..\CodeGeneration.Roslyn.Tool\$(Configuration)\netcoreapp2.1\dotnet-codegen.dll</GenerateCodeFromAttributesToolPathOverride>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CodeGeneration.Roslyn.Tests/Helpers/CompilationTestsBase.cs
+++ b/src/CodeGeneration.Roslyn.Tests/Helpers/CompilationTestsBase.cs
@@ -23,6 +23,7 @@ public abstract class CompilationTestsBase
         var coreAssemblyNames = new[]
         {
             "mscorlib.dll",
+            "netstandard.dll",
             "System.dll",
             "System.Core.dll",
 #if NETCOREAPP

--- a/src/CodeGeneration.Roslyn.Tool/CodeGeneration.Roslyn.Tool.csproj
+++ b/src/CodeGeneration.Roslyn.Tool/CodeGeneration.Roslyn.Tool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageType>DotnetCliTool</PackageType>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-codegen</AssemblyName>
     <Description>The dotnet code generation tool that works with the CodeGeneration.Roslyn nuget package.</Description>
     <CodeAnalysisRuleSet>CodeGeneration.Roslyn.Tool.ruleset</CodeAnalysisRuleSet>

--- a/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
+++ b/src/CodeGeneration.Roslyn/CodeGeneration.Roslyn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>A package that offers libraries for creating a code generation attribute and the associated generator.</Description>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
     <OutputPath>$(MSBuildThisFileDirectory)../bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)../bin/Packages/$(Configuration)/</PackageOutputPath>
     <IsTestingOnlyProject>$(MSBuildProjectName.Contains('Test'))</IsTestingOnlyProject>
-    <RoslynNugetVersion>2.9.0</RoslynNugetVersion>
+    <RoslynNugetVersion>3.0.0</RoslynNugetVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" !$(IsTestingOnlyProject) ">


### PR DESCRIPTION
So, since the project right now is completely independent of Visual Studio version, I've upgraded Roslyn to v3.0 and targeted netstandard2.0, and the tool itself now targets netcoreapp2.1.

The only requirements are:
* SDK-style csproj for DotNetCliTool to resolve and
* .NET Core SDK 2.1+ to run it

Thanks to CodeGeneration.Roslyn not integrating with MSBuild now, the tool runs as a .NET Core app completely independent of all the other parts (VS, MSBuild, platform etc). The price is that we always use our own Roslyn version which we need to update manually.

Triggered by, and closes #124