### PR TITLE
Remove DotNetCliToolReference from BuildTime .props

### DIFF
--- a/src/CodeGeneration.Roslyn.Tasks/CodeGeneration.Roslyn.Tasks.csproj
+++ b/src/CodeGeneration.Roslyn.Tasks/CodeGeneration.Roslyn.Tasks.csproj
@@ -11,7 +11,6 @@
     </TargetFrameworks>
     <PackageId>CodeGeneration.Roslyn.BuildTime</PackageId>
     <Description>The build-time development dependency that generates code for a project that consumes code generation attributes.</Description>
-    <BeforePack>SetPackageVersionInProps;$(BeforePack)</BeforePack>
     <PropsFileName>$(PackageId).props</PropsFileName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/src/CodeGeneration.Roslyn.Tasks/CodeGeneration.Roslyn.Tasks.csproj
+++ b/src/CodeGeneration.Roslyn.Tasks/CodeGeneration.Roslyn.Tasks.csproj
@@ -38,23 +38,4 @@
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
   </ItemDefinitionGroup>
-
-  <Target Name="SetPackageVersionInProps" DependsOnTargets="GetBuildVersion">
-    <PropertyGroup>
-      <PropsFileDestinationDirectory>$(IntermediateOutputPath)build\</PropsFileDestinationDirectory>
-      <PropsFilePath>$(PropsFileDestinationDirectory)\$(PropsFileName)</PropsFilePath>
-      <_ProjectNamespaces>
-        <Namespace Prefix="dn" Uri="http://schemas.microsoft.com/developer/msbuild/2003" />
-      </_ProjectNamespaces>
-    </PropertyGroup>
-    <MakeDir Directories="$(PropsFileDestinationDirectory)" />
-    <Copy SourceFiles="build\$(PropsFileName)" DestinationFiles="$(PropsFilePath)" />
-    <XmlPoke XmlInputPath="$(PropsFilePath)" Value="$(PackageVersion)" Query="/dn:Project/dn:ItemGroup/dn:DotNetCliToolReference/@Version" Namespaces="$(_ProjectNamespaces)" />
-    <ItemGroup>
-      <None Include="$(PropsFilePath)">
-        <Pack>true</Pack>
-        <PackagePath>build\</PackagePath>
-      </None>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.props
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.props
@@ -1,14 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <!--Version metadata is updated to match the package's one
-        by SetPackageVersionInProps target in .csproj-->
-    <DotNetCliToolReference Include="dotnet-codegen" Version="*" />
-  </ItemGroup>
-
+  
   <ItemDefinitionGroup>
     <Compile>
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
     </Compile>
   </ItemDefinitionGroup>
+  
 </Project>


### PR DESCRIPTION
closes #134

For reasoning and explanation, see issue above.