### PR TITLE
Fix/102 error surfacing

### DIFF
--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
@@ -29,9 +29,8 @@
       <_CodeGenToolOutputBasePath>$(IntermediateOutputPath)$(MSBuildProjectFile).dotnet-codegen</_CodeGenToolOutputBasePath>
       <_CodeGenToolResponseFileFullPath>$(_CodeGenToolOutputBasePath).rsp</_CodeGenToolResponseFileFullPath>
       <_CodeGenToolGeneratedFileListFullPath>$(_CodeGenToolOutputBasePath).GeneratedFileList.txt</_CodeGenToolGeneratedFileListFullPath>
-      <_CodeGenToolWarningText>dotnet-codegen: Failed to generate the list of generated files. The tool didn't run successfully. Please check https://github.com/AArnott/CodeGeneration.Roslyn for usage instructions.</_CodeGenToolWarningText>
       <_CodeGenToolResponseFileLines>
-@(ReferencePath->'-r%0d%0a%(Identity)', '%0d%0a')
+        <![CDATA[@(ReferencePath->'-r%0d%0a%(Identity)', '%0d%0a')
 @(DefineConstantsItems->'-d%0d%0a%(Identity)', '%0d%0a')
 @(GeneratorAssemblySearchPaths->'--generatorSearchPath%0d%0a%(Identity)', '%0d%0a')
 --out
@@ -41,9 +40,10 @@ $(MSBuildProjectDirectory)
 --generatedFilesList
 $(_CodeGenToolGeneratedFileListFullPath)
 --
-@(Compile_CodeGenInputs, '%0d%0a')
+@(Compile_CodeGenInputs, '%0d%0a')]]>
       </_CodeGenToolResponseFileLines>
       <_GenerateCodeToolVersion>(n/a)</_GenerateCodeToolVersion>
+      <_GenerateCodeToolVersionExitCode></_GenerateCodeToolVersionExitCode>
     </PropertyGroup>
     <!--Write response file with arguments for dotnet codegen-->
     <WriteLinesToFile
@@ -61,10 +61,16 @@ $(_CodeGenToolGeneratedFileListFullPath)
       StandardOutputImportance="normal"
       ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_GenerateCodeToolVersion"/>
+      <Output TaskParameter="ExitCode" PropertyName="_GenerateCodeToolVersionExitCode"/>
     </Exec>
     <Message
-      Text="Running CodeGeneration.Roslyn.Tool v$(_GenerateCodeToolVersion)"
-      Importance="normal" />
+      Text="CodeGeneration.Roslyn.Tool (dotnet-codegen) version: $(_GenerateCodeToolVersion)"
+      Importance="normal"
+      Condition="'$(_GenerateCodeToolVersionExitCode)' == '0'" />
+    <Error
+      Code="CGR1001"
+      Text="CodeGeneration.Roslyn.Tool (dotnet-codegen) is not available, code generation won't run. Please check https://github.com/AArnott/CodeGeneration.Roslyn for usage instructions."
+      Condition="'$(_GenerateCodeToolVersionExitCode)' != '0'" />
     <ItemGroup>
       <FileWrites Include="$(_CodeGenToolResponseFileFullPath)" />
     </ItemGroup>
@@ -76,9 +82,9 @@ $(_CodeGenToolGeneratedFileListFullPath)
       Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) &quot;%40$(_CodeGenToolResponseFileFullPath)&quot;"
       StandardOutputImportance="normal" />
     <Error
-      Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') != 'true'"
       Code="CGR1000"
-      Text="$(_CodeGenToolWarningText)" />
+      Text="CodeGeneration.Roslyn.Tool (dotnet-codegen) failed to generate the list of generated files. The tool didn't run successfully. Please check https://github.com/AArnott/CodeGeneration.Roslyn for usage instructions."
+      Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') != 'true'" />
     <ReadLinesFromFile File="$(_CodeGenToolGeneratedFileListFullPath)">
       <Output TaskParameter="Lines" ItemName="CodeGenerationRoslynOutput_Compile"/>
       <Output TaskParameter="Lines" ItemName="FileWrites"/>
@@ -88,5 +94,5 @@ $(_CodeGenToolGeneratedFileListFullPath)
       <FileWrites Include="$(_CodeGenToolGeneratedFileListFullPath)" />
     </ItemGroup>
   </Target>
-  
+
 </Project>

--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
@@ -74,9 +74,8 @@ $(_CodeGenToolGeneratedFileListFullPath)
     <!--Run the tool and process results-->
     <Exec
       Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) &quot;%40$(_CodeGenToolResponseFileFullPath)&quot;"
-      StandardOutputImportance="normal"
-      ContinueOnError="true" />
-    <Warning
+      StandardOutputImportance="normal" />
+    <Error
       Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') != 'true'"
       Code="CGR1000"
       Text="$(_CodeGenToolWarningText)" />

--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
@@ -30,25 +30,28 @@
       <_CodeGenToolResponseFileFullPath>$(_CodeGenToolOutputBasePath).rsp</_CodeGenToolResponseFileFullPath>
       <_CodeGenToolGeneratedFileListFullPath>$(_CodeGenToolOutputBasePath).GeneratedFileList.txt</_CodeGenToolGeneratedFileListFullPath>
       <_CodeGenToolResponseFileLines>
-        <![CDATA[@(ReferencePath->'-r%0d%0a%(Identity)', '%0d%0a')
-@(DefineConstantsItems->'-d%0d%0a%(Identity)', '%0d%0a')
-@(GeneratorAssemblySearchPaths->'--generatorSearchPath%0d%0a%(Identity)', '%0d%0a')
---out
-$(IntermediateOutputPath)
---projectDir
-$(MSBuildProjectDirectory)
---generatedFilesList
-$(_CodeGenToolGeneratedFileListFullPath)
---
-@(Compile_CodeGenInputs, '%0d%0a')]]>
+        @(ReferencePath->'-r;%(Identity)');
+        @(DefineConstantsItems->'-d;%(Identity)');
+        @(GeneratorAssemblySearchPaths->'--generatorSearchPath;%(Identity)');
+        --out;
+        $(IntermediateOutputPath);
+        --projectDir;
+        $(MSBuildProjectDirectory);
+        --generatedFilesList;
+        $(_CodeGenToolGeneratedFileListFullPath);
+        --;
+        @(Compile_CodeGenInputs)
       </_CodeGenToolResponseFileLines>
       <_GenerateCodeToolVersion>(n/a)</_GenerateCodeToolVersion>
       <_GenerateCodeToolVersionExitCode></_GenerateCodeToolVersionExitCode>
     </PropertyGroup>
+    <ItemGroup>
+      <_CodeGenToolResponseFileContent Include="$(_CodeGenToolResponseFileLines)" />
+    </ItemGroup>
     <!--Write response file with arguments for dotnet codegen-->
     <WriteLinesToFile
       File="$(_CodeGenToolResponseFileFullPath)"
-      Lines="$(_CodeGenToolResponseFileLines)"
+      Lines="@(_CodeGenToolResponseFileContent)"
       Overwrite="true" />
     <Delete
       Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') == 'true'"

--- a/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
+++ b/src/CodeGeneration.Roslyn.Tasks/build/CodeGeneration.Roslyn.BuildTime.targets
@@ -10,16 +10,22 @@
     </GenerateCodeFromAttributesDependsOn>
   </PropertyGroup>
 
-  <Target Name="GenerateCodeFromAttributes" DependsOnTargets="$(GenerateCodeFromAttributesDependsOn)" BeforeTargets="CoreCompile;PrepareResources">
+  <Target
+    Name="GenerateCodeFromAttributes"
+    DependsOnTargets="$(GenerateCodeFromAttributesDependsOn)"
+    BeforeTargets="CoreCompile;PrepareResources">
   </Target>
 
   <Target Name="PrepareGenerateCodeFromAttributes">
     <ItemGroup>
-      <Compile_CodeGenInputs Include="@(Compile)" Condition=" '%(Compile.Generator)' == 'MSBuild:GenerateCodeFromAttributes' " />
+      <Compile_CodeGenInputs
+        Include="@(Compile)"
+        Condition=" '%(Compile.Generator)' == 'MSBuild:GenerateCodeFromAttributes' " />
       <DefineConstantsItems Include="$(DefineConstants)" />
     </ItemGroup>
     <PropertyGroup>
-      <GenerateCodeFromAttributesToolPathOverride Condition="'$(GenerateCodeFromAttributesToolPathOverride)' == ''">codegen</GenerateCodeFromAttributesToolPathOverride>
+      <GenerateCodeFromAttributesToolPathOverride
+        Condition="'$(GenerateCodeFromAttributesToolPathOverride)' == ''">codegen</GenerateCodeFromAttributesToolPathOverride>
       <_CodeGenToolOutputBasePath>$(IntermediateOutputPath)$(MSBuildProjectFile).dotnet-codegen</_CodeGenToolOutputBasePath>
       <_CodeGenToolResponseFileFullPath>$(_CodeGenToolOutputBasePath).rsp</_CodeGenToolResponseFileFullPath>
       <_CodeGenToolGeneratedFileListFullPath>$(_CodeGenToolOutputBasePath).GeneratedFileList.txt</_CodeGenToolGeneratedFileListFullPath>
@@ -40,15 +46,25 @@ $(_CodeGenToolGeneratedFileListFullPath)
       <_GenerateCodeToolVersion>(n/a)</_GenerateCodeToolVersion>
     </PropertyGroup>
     <!--Write response file with arguments for dotnet codegen-->
-    <WriteLinesToFile File="$(_CodeGenToolResponseFileFullPath)" Lines="$(_CodeGenToolResponseFileLines)" Overwrite="true" />
-    <Delete Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') == 'true'"
-            Files="$(_CodeGenToolGeneratedFileListFullPath)" ContinueOnError="true" />
+    <WriteLinesToFile
+      File="$(_CodeGenToolResponseFileFullPath)"
+      Lines="$(_CodeGenToolResponseFileLines)"
+      Overwrite="true" />
+    <Delete
+      Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') == 'true'"
+      Files="$(_CodeGenToolGeneratedFileListFullPath)"
+      ContinueOnError="true" />
     <!--Check and print tool version used-->
-    <Exec Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) --version" ConsoleToMsBuild="true"
-          StandardOutputImportance="normal" ContinueOnError="true">
+    <Exec
+      Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) --version"
+      ConsoleToMsBuild="true"
+      StandardOutputImportance="normal"
+      ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_GenerateCodeToolVersion"/>
     </Exec>
-    <Message Text="Running CodeGeneration.Roslyn.Tool v$(_GenerateCodeToolVersion)" Importance="normal" />
+    <Message
+      Text="Running CodeGeneration.Roslyn.Tool v$(_GenerateCodeToolVersion)"
+      Importance="normal" />
     <ItemGroup>
       <FileWrites Include="$(_CodeGenToolResponseFileFullPath)" />
     </ItemGroup>
@@ -56,10 +72,14 @@ $(_CodeGenToolGeneratedFileListFullPath)
 
   <Target Name="GenerateCodeFromAttributesCore" Condition="'@(Compile_CodeGenInputs)' != ''">
     <!--Run the tool and process results-->
-    <Exec Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) &quot;%40$(_CodeGenToolResponseFileFullPath)&quot;"
-          StandardOutputImportance="normal"  ContinueOnError="true" />
-    <Warning Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') != 'true'"
-             Text="$(_CodeGenToolWarningText)" Code="CGR1000" />
+    <Exec
+      Command="dotnet $(GenerateCodeFromAttributesToolPathOverride) &quot;%40$(_CodeGenToolResponseFileFullPath)&quot;"
+      StandardOutputImportance="normal"
+      ContinueOnError="true" />
+    <Warning
+      Condition="Exists('$(_CodeGenToolGeneratedFileListFullPath)') != 'true'"
+      Code="CGR1000"
+      Text="$(_CodeGenToolWarningText)" />
     <ReadLinesFromFile File="$(_CodeGenToolGeneratedFileListFullPath)">
       <Output TaskParameter="Lines" ItemName="CodeGenerationRoslynOutput_Compile"/>
       <Output TaskParameter="Lines" ItemName="FileWrites"/>
@@ -69,4 +89,5 @@ $(_CodeGenToolGeneratedFileListFullPath)
       <FileWrites Include="$(_CodeGenToolGeneratedFileListFullPath)" />
     </ItemGroup>
   </Target>
+  
 </Project>


### PR DESCRIPTION
Only the dbcd71d commit is actually the fix

Aside from reformatting the msbuild file for better readability, there are following enhancements:
* `.rsp` file generation is generating lines using `ItemGroup` functionality, which results in a more readable target (IMHO). As a result, usage of `%0d%0a` for newline was dropped.
* More human-readable error message for when `dotnet codegen --version` fails, and a message when it succeeds.
* Not-swallowing non-0 exit code for main invocation as per #102
* An error instead of a warning for when the command exited with `0` but the `.GeneratedFileList.txt` file doesn't exist. It's an error, because by design on a successful run the file won't be created only if the file list path was not passed as a parameter, and it's passed in the target provided by us.