### PR TITLE
.NET Core 3 support dotnet-codegen

### DIFF
--- a/src/CodeGeneration.Roslyn.Tool/runtimeconfig.template.json
+++ b/src/CodeGeneration.Roslyn.Tool/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForward": "Major"
+}


### PR DESCRIPTION
Create runtimeconfig.template.json containing rollForward for .NET Core 3 support

This is what was done for FAKE: https://github.com/fsharp/FAKE/issues/2325
Fixes #169
