### PR TITLE
Support C# Code Snippets to generate code.

### DIFF
--- a/src/CodeGeneration.Roslyn.Tests/CSharpCodeSnippetTest.cs
+++ b/src/CodeGeneration.Roslyn.Tests/CSharpCodeSnippetTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MS-PL license. See LICENSE.txt file in the project root for full license information.
+
+namespace CodeGeneration.Roslyn.Tests
+{
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Xunit;
+
+    public class CSharpCodeSnippetTest
+    {
+        [Fact]
+        public async Task ParseAsync_StructDefinition_Parsed()
+        {
+            var snippet = new SimpleCodeSnippet(@"
+public struct @Name
+{
+    public @Name(int count) => Count = count;
+    public int Count { get; }
+}");
+
+            var syntax = await snippet.ParseAysnc<StructDeclarationSyntax>(new TransformArguments { Name = "TestStruct" });
+
+            var expected = @"
+public struct TestStruct
+{
+    public TestStruct(int count) => Count = count;
+    public int Count { get; }
+}";
+            Assert.Equal(expected, syntax.ToFullString());
+        }
+
+        [Fact]
+        public async Task ParseAsync_MethodDeclaration_Parsed()
+        {
+            var snippet = new SimpleCodeSnippet(@"public string ToDebug(string par) => par.ToUpper();");
+            var syntax = await snippet.ParseAysnc<MethodDeclarationSyntax>();
+
+            var expected = @"public string ToDebug(string par) => par.ToUpper();";
+            Assert.Equal(expected, syntax.ToFullString());
+        }
+    }
+
+    internal class SimpleCodeSnippet : CSharpCodeSnippet<TransformArguments>
+    {
+        public SimpleCodeSnippet(string text)
+            : base(text, "test.cs", null) { }
+
+        protected override string TransformText(TransformArguments arguments)
+        {
+            return Text.Replace("@Name", arguments.Name);
+        }
+    }
+
+    internal class TransformArguments
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/CodeGeneration.Roslyn/CSharpCodeSnippet.cs
+++ b/src/CodeGeneration.Roslyn/CSharpCodeSnippet.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MS-PL license. See LICENSE.txt file in the project root for full license information.
+
+namespace CodeGeneration.Roslyn
+{
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+
+    /// <summary>Represents a C# code snippet.</summary>
+    /// <typeparam name="TSnippetArguments">
+    /// An argument class that helps transforming the text befor parsing it.
+    /// </typeparam>
+    public abstract class CSharpCodeSnippet<TSnippetArguments>
+        where TSnippetArguments : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CSharpCodeSnippet{TSnippetArguments}"/> class.
+        /// </summary>
+        /// <param name="text">
+        /// The text of the code snippet.
+        /// </param>
+        /// <param name="fileName">
+        /// The file name of the code snippet (optional).
+        /// </param>
+        /// <param name="parseOptions">
+        /// The parse options.
+        /// </param>
+        protected CSharpCodeSnippet(string text, string fileName, CSharpParseOptions parseOptions)
+        {
+            Text = text;
+            FileName = fileName;
+            ParseOptions = parseOptions ?? CSharpParseOptions.Default;
+        }
+
+        /// <summary>Gets the (untransformed) text of the code snippet.</summary>
+        public string Text { get; }
+
+        /// <summary>Gets the file name of the code snippet.</summary>
+        public string FileName { get; }
+
+        /// <summary>Gets the <see cref="CSharpParseOptions"/> to parse the <see cref="Text"/> with.</summary>
+        public CSharpParseOptions ParseOptions { get; }
+
+        /// <summary>Parses the code snippet.</summary>
+        /// <typeparam name="TSyntax">
+        /// The <see cref="SyntaxNode"/> type of the code snippet.
+        /// </typeparam>
+        /// <returns>
+        /// The parsed <see cref="SyntaxNode"/> of the code snippet.
+        /// </returns>
+        public Task<TSyntax> ParseAysnc<TSyntax>()
+            where TSyntax : SyntaxNode
+        {
+            return ParseAysnc<TSyntax>(default);
+        }
+
+        /// <summary>Parses the code snippet.</summary>
+        /// <typeparam name="TSyntax">
+        /// The <see cref="SyntaxNode"/> type of the code snippet.
+        /// </typeparam>
+        /// <param name="arguments">
+        /// The (optional) arguments to transform the code snippet before parsing.
+        /// </param>
+        /// <returns>
+        /// The parsed <see cref="SyntaxNode"/> of the code snippet.
+        /// </returns>
+        public async Task<TSyntax> ParseAysnc<TSyntax>(TSnippetArguments arguments)
+            where TSyntax : SyntaxNode
+        {
+            var tranformed = arguments is null ? Text : TransformText(arguments);
+
+            var tree = CSharpSyntaxTree.ParseText(tranformed, ParseOptions, FileName, Encoding.UTF8, default);
+            var root = await tree.GetRootAsync(default);
+
+            return root is TSyntax requested
+                ? requested
+                : root.ChildNodes().FirstOrDefault(ch => ch is TSyntax) as TSyntax;
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => Text;
+
+        /// <summary>Transforms the text before parsing it.</summary>
+        /// <param name="arguments">
+        /// The arguments to transform the code snippet before parsing.
+        /// </param>
+        /// <returns>
+        /// The transformed <see cref="Text"/>.
+        /// </returns>
+        protected abstract string TransformText(TSnippetArguments arguments);
+    }
+}


### PR DESCRIPTION
Using code snippets as starting point for code generation can make the code generator much easier to read/maintain. Writing code with the `SyntaxTreeFactory` can be hard.

So how does should this work?

We have some file (embedded, or disk)
``` C#
public struct @Name
{
    public @Name(int count) => Count = count;
    public int Count { get; }
}
```

With some simple generator files. What kind of transform you want to apply should be as free as possible, so let the generator decide for its own. In this example its a simple string replace.
``` C#
class SimpleCodeSnippet : CSharpCodeSnippet<TransformArguments>
{
    public SimpleCodeSnippet(string text)
        : base(text, "test.cs", null) { }

    protected override string TransformText(TransformArguments arguments)
    {
        return Text.Replace("@Name", arguments.Name);
    }
}
class TransformArguments
{
    public string Name { get; set; }
}
````

This can be used like this:
``` C#
SimpleCodeSnippet snippet = GetCodeSnippet(); // embedded resource, disk, whatever.
var syntax = await snippet.ParseAysnc<StructDeclarationSyntax>(new TransformArguments { Name = "TestStruct" });
```