### PR TITLE
Add example for a generator respecting nullability

### DIFF
--- a/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
@@ -76,29 +76,14 @@ namespace CodeGeneration.Roslyn.Tests.Generators
                                 ReturnStatement(
                                     IdentifierName("value")))));
 
-                if (isNullableEnabled)
-                {
-                    methodDoSomething = methodDoSomething.WithLeadingTrivia(TriviaList(Trivia(
-                            NullableDirectiveTrivia(
-                                Token(SyntaxKind.EnableKeyword),
-                                true))))
-                        .WithTrailingTrivia(TriviaList(Trivia(
-                            NullableDirectiveTrivia(
-                                Token(SyntaxKind.RestoreKeyword),
-                                true))));
-                    methodDoSomethingStrict = methodDoSomethingStrict.WithLeadingTrivia(TriviaList(Trivia(
-                            NullableDirectiveTrivia(
-                                Token(SyntaxKind.EnableKeyword),
-                                true))))
-                        .WithTrailingTrivia(TriviaList(Trivia(
-                            NullableDirectiveTrivia(
-                                Token(SyntaxKind.RestoreKeyword),
-                                true))));
-                }
+                var leading = isNullableEnabled ? TriviaList(Trivia(NullableDirectiveTrivia(Token(SyntaxKind.EnableKeyword), true))) : SyntaxTriviaList.Empty;
+                var trailing = isNullableEnabled ? TriviaList(Trivia(NullableDirectiveTrivia(Token(SyntaxKind.RestoreKeyword), true))) : SyntaxTriviaList.Empty;
 
                 copy = ClassDeclaration(applyToClass.Identifier)
                     .WithModifiers(applyToClass.Modifiers)
-                    .AddMembers(methodDoSomething, methodDoSomethingStrict);
+                    .WithLeadingTrivia(leading)
+                    .AddMembers(methodDoSomething, methodDoSomethingStrict)
+                    .WithTrailingTrivia(trailing);
             }
 
             if (copy != null)

--- a/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
@@ -1,0 +1,79 @@
+﻿using System;
+namespace CodeGeneration.Roslyn.Tests.Generators
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Validation;
+    using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+    public class NullableGenerator : ICodeGenerator
+    {
+        public NullableGenerator(AttributeData attributeData)
+        {
+            Requires.NotNull(attributeData, nameof(attributeData));
+        }
+
+        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
+        {
+            var results = List<MemberDeclarationSyntax>();
+            MemberDeclarationSyntax copy = null;
+            if (context.ProcessingNode is ClassDeclarationSyntax applyToClass)
+            {
+                var nullableContext = context.SemanticModel.GetNullableContext(applyToClass.SpanStart);
+                var isNullableEnabled = nullableContext == NullableContext.Enabled;
+                var method = MethodDeclaration(
+                        MakeNullableIfEnabled(
+                            PredefinedType(
+                                Token(SyntaxKind.StringKeyword)), isNullableEnabled),
+                        Identifier("DoSomething"))
+                    .WithModifiers(
+                        TokenList(
+                            Token(SyntaxKind.PublicKeyword)))
+                    .WithParameterList(
+                        ParameterList(
+                            SingletonSeparatedList(
+                                Parameter(
+                                        Identifier("value"))
+                                    .WithType(
+                                        MakeNullableIfEnabled(
+                                            PredefinedType(
+                                                Token(SyntaxKind.StringKeyword)), isNullableEnabled)))))
+                    .WithBody(
+                        Block(
+                            SingletonList<StatementSyntax>(
+                                ReturnStatement(
+                                    IdentifierName("value")))));
+                if (isNullableEnabled)
+                {
+                    method = method.WithLeadingTrivia(TriviaList(Trivia(
+                            NullableDirectiveTrivia(
+                                Token(SyntaxKind.EnableKeyword),
+                                true))))
+                        .WithTrailingTrivia(TriviaList(Trivia(
+                            NullableDirectiveTrivia(
+                                Token(SyntaxKind.RestoreKeyword),
+                                true))));
+                }
+
+                copy = ClassDeclaration(applyToClass.Identifier)
+                    .WithModifiers(applyToClass.Modifiers)
+                    .AddMembers(method);
+            }
+
+            if (copy != null)
+            {
+                results = results.Add(copy);
+            }
+
+            return Task.FromResult(results);
+        }
+
+        public static TypeSyntax MakeNullableIfEnabled(TypeSyntax typeSyntax, bool isEnabled)
+        {
+            return isEnabled ? NullableType(typeSyntax) : typeSyntax;
+        }
+    }
+}

--- a/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Tests.Generators/NullableGenerator.cs
@@ -1,6 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MS-PL license. See LICENSE.txt file in the project root for full license information.
+
 namespace CodeGeneration.Roslyn.Tests.Generators
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;

--- a/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
@@ -7,7 +7,6 @@
     <GenerateCodeFromAttributesToolPathOverride>$(OutputPath)..\..\CodeGeneration.Roslyn.Tool\$(Configuration)\netcoreapp2.1\dotnet-codegen.dll</GenerateCodeFromAttributesToolPathOverride>
     <!-- Ignore CGR1002 because it's expected to be raised by legacy Amadevus.RecordGenerator -->
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);CGR1002</MSBuildWarningsAsMessages>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
+++ b/src/CodeGeneration.Roslyn.Tests/CodeGeneration.Roslyn.Tests.csproj
@@ -7,6 +7,7 @@
     <GenerateCodeFromAttributesToolPathOverride>$(OutputPath)..\..\CodeGeneration.Roslyn.Tool\$(Configuration)\netcoreapp2.1\dotnet-codegen.dll</GenerateCodeFromAttributesToolPathOverride>
     <!-- Ignore CGR1002 because it's expected to be raised by legacy Amadevus.RecordGenerator -->
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);CGR1002</MSBuildWarningsAsMessages>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
@@ -1,0 +1,48 @@
+﻿namespace CodeGeneration.Roslyn.Tests.OtherFolder
+{
+    using System;
+    using System.Diagnostics;
+    using CodeGeneration.Roslyn.Tests.Generators;
+    using Xunit;
+
+    public class NullableGeneratorTests
+    {
+#nullable enable
+        [Fact]
+        public void TestForWhichNullableIsEnabled()
+        {
+            var instance = new NullableEnabled();
+            _ = instance.DoSomething("blub");
+        }
+
+#nullable disable
+        [Fact]
+        public void TestForWhichNullableIsDisabled()
+        {
+            var instance = new NullableDisabled();
+            _ = instance.DoSomething("blub");
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [CodeGenerationAttribute(typeof(NullableGenerator))]
+    [Conditional("CodeGeneration")]
+    public class NullableGeneratorAttribute : Attribute
+    {
+        // nothing to do here
+    }
+
+#nullable enable
+    [NullableGenerator]
+    public partial class NullableEnabled
+    {
+        // an method string? DoSomething(string?) will be generated
+    }
+
+#nullable disable
+    [NullableGenerator]
+    public partial class NullableDisabled
+    {
+        // an method string DoSomething(string) will be generated
+    }
+}

--- a/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
@@ -1,4 +1,7 @@
-﻿namespace CodeGeneration.Roslyn.Tests.OtherFolder
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MS-PL license. See LICENSE.txt file in the project root for full license information.
+
+namespace CodeGeneration.Roslyn.Tests.OtherFolder
 {
     using System;
     using System.Diagnostics;

--- a/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
+++ b/src/CodeGeneration.Roslyn.Tests/OtherFolder/NullableGeneratorTests.cs
@@ -10,20 +10,25 @@ namespace CodeGeneration.Roslyn.Tests.OtherFolder
 
     public class NullableGeneratorTests
     {
-#nullable enable
         [Fact]
         public void TestForWhichNullableIsEnabled()
         {
+#nullable enable
             var instance = new NullableEnabled();
-            _ = instance.DoSomething("blub");
+            var result = instance.DoSomething("blub");
+#pragma warning disable CS8604 // Possible null reference argument. If the pragma is removed, the compiler warns that "result" can be null
+            _ = instance.DoSomethingStrict(result);
+#pragma warning restore CS8604 // Possible null reference argument.
+#nullable restore
         }
 
-#nullable disable
         [Fact]
         public void TestForWhichNullableIsDisabled()
         {
+#nullable disable
             var instance = new NullableDisabled();
             _ = instance.DoSomething("blub");
+#nullable restore
         }
     }
 
@@ -41,6 +46,7 @@ namespace CodeGeneration.Roslyn.Tests.OtherFolder
     {
         // an method string? DoSomething(string?) will be generated
     }
+#nullable restore
 
 #nullable disable
     [NullableGenerator]
@@ -48,4 +54,5 @@ namespace CodeGeneration.Roslyn.Tests.OtherFolder
     {
         // an method string DoSomething(string) will be generated
     }
+#nullable restore
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <TreatWarningsAsErrors Condition=" '$(Configuration)' == Release ">true</TreatWarningsAsErrors>


### PR DESCRIPTION
This PR adds a generator respecting the nullability context of the class.

For the class `NullableEnabled` where `#nullable enable` it generates a method `string? DoSomething(string?)`. In the generated code nullable is enabled and restored properly.

For the class `NullableDisabled` where `#nullable disable` it generates a method `string DoSomething(string)`.

can solve issue #183 . I did not read the whole conversation properly 🤨