### PR TITLE
fix: Rename ReleaseNotes to PackageReleaseNotes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <PackageProjectUrl>https://github.com/aarnott/CodeGeneration.Roslyn</PackageProjectUrl>
     <RepositoryUrl>https://github.com/aarnott/CodeGeneration.Roslyn</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <ReleaseNotes>https://github.com/AArnott/CodeGeneration.Roslyn/blob/master/CHANGELOG.md</ReleaseNotes>
+    <PackageReleaseNotes>https://github.com/AArnott/CodeGeneration.Roslyn/blob/master/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`ReleaseNotes` is an incorrect name for the property and is not included in package. See https://www.nuget.org/packages/CodeGeneration.Roslyn/0.7.5-alpha