### PR TITLE
Include custom props/targets files in packages

### DIFF
--- a/samples/PackagedGenerator/PackagedGenerator.csproj
+++ b/samples/PackagedGenerator/PackagedGenerator.csproj
@@ -7,6 +7,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <CodeGenerationRoslynPackagePropFiles Include="PackagedGenerator.props" />
+    <CodeGenerationRoslynPackageTargetFiles Include="PackagedGenerator.targets" />
+  </ItemGroup>
+
   <Import Project="$(CodeGenerationRoslynPluginSdkPath)Sdk.targets" />
 
 </Project>

--- a/samples/PackagedGenerator/PackagedGenerator.props
+++ b/samples/PackagedGenerator/PackagedGenerator.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <Foo>Bar</Foo>
+    </PropertyGroup>
+</Project>

--- a/samples/PackagedGenerator/PackagedGenerator.targets
+++ b/samples/PackagedGenerator/PackagedGenerator.targets
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup>
+        <ExampleItem Include="Foo" />
+    </ItemGroup>
+</Project>

--- a/src/CodeGeneration.Roslyn.Plugin.Sdk/build/BuildPluginPackage.targets
+++ b/src/CodeGeneration.Roslyn.Plugin.Sdk/build/BuildPluginPackage.targets
@@ -53,6 +53,8 @@
         <![CDATA[
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  @(CodeGenerationRoslynPackagePropFiles->'<Import Project="%24(MSBuildThisFileDirectory)../build-custom/%(Identity)" />')
+
   <ItemGroup>
     <CodeGenerationRoslynPlugin Include="%24(MSBuildThisFileDirectory)../$(PluginPackagePath)/$(TargetFileName)" />
   </ItemGroup>
@@ -63,6 +65,8 @@
         <![CDATA[
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  @(CodeGenerationRoslynPackageTargetFiles->'<Import Project="%24(MSBuildThisFileDirectory)../build-custom/%(Identity)" />')
+
   <Target Name="CheckCgrToolUsed" BeforeTargets="Build">
     <Warning Condition=" '%24(UsingCodeGenerationRoslynToolTargets)' != 'true' " Text="CodeGeneration.Roslyn.Tool build targets weren't detected. CG.R Plugins (generators) won't be run without importing targets from the CodeGeneration.Roslyn.Tool package (v$(PackageVersion))." />
   </Target>
@@ -75,6 +79,8 @@
     <WriteLinesToFile File="$(PackagePropsPath)" Lines="$(PackagePropsContent)" Overwrite="true" />
     <WriteLinesToFile File="$(PackageTargetsPath)" Lines="$(PackageTargetsContent)" Overwrite="true" />
     <ItemGroup>
+      <TfmSpecificPackageFile Include="@(CodeGenerationRoslynPackagePropFiles->'$(MSBuilldProjectDirectory)%(Identity)');" Pack="true" PackagePath="build-custom/" />
+      <TfmSpecificPackageFile Include="@(CodeGenerationRoslynPackageTargetFiles->'$(MSBuilldProjectDirectory)%(Identity)');" Pack="true" PackagePath="build-custom/" />
       <TfmSpecificPackageFile Include="$(PackagePropsPath);$(PackageTargetsPath)" Pack="true" PackagePath="build/" BuildAction="None" />
       <FileWrites Include="$(PackagePropsPath);$(PackageTargetsPath)" />
     </ItemGroup>


### PR DESCRIPTION
A downside of the new SDK system introduced in 0.7 is that I can no longer (easily) add my own package props/targets.  The current workaround is to do something like:

1. Add a target that runs before pack to rename the build/packageId.{props|targets} files to something else and import them or
2. Rewrite the build/packageId.{props|targets} files to include your own

I would personally prefer to not do either of those, so this PR implements a way to configure the SDK to include them when it creates the build/packageId.{props|targets} files

TODO: 
- [ ] Update readme