### PR TITLE
feat: Allow override of the generated files output path

### DIFF
--- a/src/CodeGeneration.Roslyn.Tool/build/CodeGeneration.Roslyn.Tool.targets
+++ b/src/CodeGeneration.Roslyn.Tool/build/CodeGeneration.Roslyn.Tool.targets
@@ -64,6 +64,8 @@
       <CodeGenerationRoslynToolPath
         Condition="'$(GenerateCodeFromAttributesToolPathOverride)' != ''">$(GenerateCodeFromAttributesToolPathOverride)</CodeGenerationRoslynToolPath>
       <CodeGenerationRoslynToolPath>$(CodeGenerationRoslynToolPath.Trim())</CodeGenerationRoslynToolPath>
+      <CodeGenerationRoslynFilesOutputPath
+        Condition="'$(CodeGenerationRoslynFilesOutputPath)' == ''">$(IntermediateOutputPath)</CodeGenerationRoslynFilesOutputPath>
       <_CodeGenToolOutputBasePath>$(IntermediateOutputPath)$(MSBuildProjectFile).dotnet-codegen</_CodeGenToolOutputBasePath>
       <_CodeGenToolResponseFileFullPath>$(_CodeGenToolOutputBasePath).rsp</_CodeGenToolResponseFileFullPath>
       <_CodeGenToolGeneratedFileListFullPath>$(_CodeGenToolOutputBasePath).GeneratedFileList.txt</_CodeGenToolGeneratedFileListFullPath>
@@ -73,7 +75,7 @@
         @(_CodeGenerationRoslynResolvedProperty->'%(Key)=%(Value)'->Replace(';', '%3B')->'--buildProperty;%(Identity)');
         @(CodeGenerationRoslynPlugin->'--plugin;%(Identity)');
         --out;
-        $(IntermediateOutputPath);
+        $(CodeGenerationRoslynFilesOutputPath);
         --projectDir;
         $(MSBuildProjectDirectory);
         --generatedFilesList;

--- a/src/CodeGeneration.Roslyn.Tool/build/CodeGeneration.Roslyn.Tool.targets
+++ b/src/CodeGeneration.Roslyn.Tool/build/CodeGeneration.Roslyn.Tool.targets
@@ -64,8 +64,8 @@
       <CodeGenerationRoslynToolPath
         Condition="'$(GenerateCodeFromAttributesToolPathOverride)' != ''">$(GenerateCodeFromAttributesToolPathOverride)</CodeGenerationRoslynToolPath>
       <CodeGenerationRoslynToolPath>$(CodeGenerationRoslynToolPath.Trim())</CodeGenerationRoslynToolPath>
-      <CodeGenerationRoslynFilesOutputPath
-        Condition="'$(CodeGenerationRoslynFilesOutputPath)' == ''">$(IntermediateOutputPath)</CodeGenerationRoslynFilesOutputPath>
+      <CodeGenerationRoslynToolOutputPath
+        Condition="'$(CodeGenerationRoslynToolOutputPath)' == ''">$(IntermediateOutputPath)</CodeGenerationRoslynToolOutputPath>
       <_CodeGenToolOutputBasePath>$(IntermediateOutputPath)$(MSBuildProjectFile).dotnet-codegen</_CodeGenToolOutputBasePath>
       <_CodeGenToolResponseFileFullPath>$(_CodeGenToolOutputBasePath).rsp</_CodeGenToolResponseFileFullPath>
       <_CodeGenToolGeneratedFileListFullPath>$(_CodeGenToolOutputBasePath).GeneratedFileList.txt</_CodeGenToolGeneratedFileListFullPath>
@@ -75,7 +75,7 @@
         @(_CodeGenerationRoslynResolvedProperty->'%(Key)=%(Value)'->Replace(';', '%3B')->'--buildProperty;%(Identity)');
         @(CodeGenerationRoslynPlugin->'--plugin;%(Identity)');
         --out;
-        $(CodeGenerationRoslynFilesOutputPath);
+        $(CodeGenerationRoslynToolOutputPath);
         --projectDir;
         $(MSBuildProjectDirectory);
         --generatedFilesList;


### PR DESCRIPTION
Allow override of the output directory where CGR.Tool writes generated files. Defaults to existing value `$(IntermediateOutputPath)` so no change for existing users.

Partially fixes #95 