### PR TITLE
Provide distinct Usings for final generated compliation unit

### DIFF
--- a/src/CodeGeneration.Roslyn.Engine/DocumentTransform.cs
+++ b/src/CodeGeneration.Roslyn.Engine/DocumentTransform.cs
@@ -110,7 +110,7 @@ namespace CodeGeneration.Roslyn.Engine
             var compilationUnit =
                 SyntaxFactory.CompilationUnit(
                         SyntaxFactory.List(emittedExterns),
-                        SyntaxFactory.List(emittedUsings),
+                        SyntaxFactory.List(emittedUsings.Distinct()),
                         SyntaxFactory.List(emittedAttributeLists),
                         SyntaxFactory.List(emittedMembers))
                     .WithLeadingTrivia(SyntaxFactory.Comment(GeneratedByAToolPreamble))


### PR DESCRIPTION
When using multiple different generators that have an overlap of Using Directives , the resulting consumer project may get a CS0105 warning "The using directive for 'Foo' appeared previously in this namespace"

I have applied Distinct() to ensure there are no duplicates in the final generated compilation.